### PR TITLE
Add support for right-click removing a playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It is not meant to be used as a serious audio player.
 
 - [x] Reference playlists by index or actual reference (not a clone...), so info is not lost when changing playlist context
 - [x] Double clicking track automatically starts to play it.
+- [x] Remove playlists.
 - [ ] Remove tracks from playlist.
 - [ ] Reorder items in playlist.
 - [ ] Save playlists.


### PR DESCRIPTION
I haven't figured out how to make context menus yet, but I can use the examples from [egui](https://github.com/emilk/egui/blob/eda1d916546ada6a9b8d5e8a96f5033e871bfeb3/egui/src/menu.rs) to make a generalized click context menu. The playlist tab has been changed to a label to make it slightly less confusing. It needs a background and border to help differentiate what it is used for.

Removing a playlist is done via a right-button (secondary) click, which sets the state for which list to remove. This is so I don't have to mutate the playlists vec while iterating. For the time being, some bounds checking needs to be done. This looks like it can be eliminated if I can figure out the lifetime issues when setting the `current_playlist` to a `&Playlist`.