### PR TITLE
Add support for next and previous buttons in the player

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ It is not meant to be used as a serious audio player.
 - [ ] Remove tracks from playlist.
 - [ ] Reorder items in playlist.
 - [ ] Save playlists.
-- [ ] Add Next and Previous controls
+- [ ] Selected track is highlighted.
+- [x] Add Next and Previous controls
 - [x] Pause is a toggle
 - [x] Play restarts the track
 - [ ] Add player indicators next to the track

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,8 @@ impl AppState {
             let stop_btn = ui.button("■");
             let play_btn = ui.button("▶");
             let pause_btn = ui.button("⏸");
+            let prev_btn = ui.button("|◀");
+            let next_btn = ui.button("▶|");
 
             if ui.button("Create Playlist +").clicked() {
                 let default_name_count = self
@@ -156,6 +158,14 @@ impl AppState {
 
                 if pause_btn.clicked() {
                     self.player.pause();
+                }
+
+                if prev_btn.clicked() {
+                    self.player.previous(&self.playlists[(self.current_playlist_idx).unwrap()])
+                }
+                
+                if next_btn.clicked() {
+                    self.player.next(&self.playlists[(self.current_playlist_idx).unwrap()])
                 }
             }
         });

--- a/src/stuff/player.rs
+++ b/src/stuff/player.rs
@@ -1,4 +1,4 @@
-use crate::stuff::playlist::Track;
+use crate::stuff::playlist::{Playlist, Track};
 
 pub struct Player {
     pub track_state: TrackState,
@@ -69,6 +69,31 @@ impl Player {
                 self.sink.play();
             }
             _ => (),
+        }
+    }
+    
+    pub fn previous(&mut self, playlist: &Playlist) {
+        if let Some(selected_track) = &self.selected_track {
+            if let Some(current_track_position) = playlist.get_pos(&selected_track) {
+                if current_track_position > 0 {
+                    let previous_track = &playlist.tracks[current_track_position - 1];
+                    self.selected_track = Some(previous_track.clone());
+                    self.play();
+                }
+            }
+
+        }
+    }
+
+    pub fn next(&mut self, playlist: &Playlist) {
+        if let Some(selected_track) = &self.selected_track {
+            if let Some(current_track_position) = playlist.get_pos(&selected_track) {
+                if current_track_position < playlist.tracks.len() - 1 {
+                    let next_track = &playlist.tracks[current_track_position + 1];
+                    self.selected_track = Some(next_track.clone());
+                    self.play();
+                }
+            }
         }
     }
 }

--- a/src/stuff/playlist.rs
+++ b/src/stuff/playlist.rs
@@ -45,6 +45,10 @@ impl Playlist {
     pub fn select(&mut self, idx: usize) {
         self.selected = Some(self.tracks[idx].clone());
     }
+
+    pub fn get_pos(&self, track: &Track) -> Option<usize> {
+        self.tracks.iter().position(|t| t == track)
+    }
 }
 
 // TODO - Probably shouldn't hold the actual bytes, but borrowed tag information after the file is opened.


### PR DESCRIPTION
Adds support for next and previous track with player buttons. I don't particularly like this implementation. This may change depending on refactoring of the `AppState`.