### PR TITLE
Add a volume slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ It is not meant to be used as a serious audio player.
 - [x] Pause is a toggle
 - [x] Play restarts the track
 - [ ] Add player indicators next to the track
-- [ ] Add volume control slider
+- [x] Add volume control slider
 - [ ] Save app state on close.
 - [ ] Set currently playing track as app Title
 - [ ] Stop with all the cloning... seriously. Everything is cloned.

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,6 +142,15 @@ impl AppState {
                 self.current_playlist_idx = Some(self.playlists.len() - 1);
             }
 
+            let mut volume = self.player.volume;
+            ui.add(
+                egui::Slider::new(&mut volume, (0.0 as f32)..=(10.0 as f32))
+                    .logarithmic(false)
+                    .show_value(false)
+                    .clamp_to_range(true)
+            );
+           self.player.set_volume(volume);
+
             if let Some(selected_track) = &self.player.selected_track {
                 ui.label("Track State: ");
                 ui.monospace(&self.player.track_state);

--- a/src/stuff/player.rs
+++ b/src/stuff/player.rs
@@ -5,6 +5,7 @@ pub struct Player {
     pub selected_track: Option<Track>,
     pub sink: rodio::Sink,
     pub stream_handle: rodio::OutputStreamHandle,
+    pub volume: f32,
 }
 
 impl Player {
@@ -14,6 +15,7 @@ impl Player {
             selected_track: None,
             sink: sink,
             stream_handle: stream_handle,
+            volume: 1.0,
         }
     }
 
@@ -95,6 +97,11 @@ impl Player {
                 }
             }
         }
+    }
+
+    pub fn set_volume(&mut self, volume: f32) {
+        self.volume = volume;
+        self.sink.set_volume(volume);
     }
 }
 


### PR DESCRIPTION
Adds a basic linear volume slider. Range was chosen arbitrarily between 0 and 10. I might experiment with making it logarithmic as that is the taper usually used in audio controls.