### PR TITLE
Add support for basic library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +808,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1058,17 @@ name = "hound"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a164bb2ceaeff4f42542bdb847c41517c78a60f5649671b2a07312b6e117549"
+
+[[package]]
+name = "id3"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8794bc5f4cab6c6066c8eda098d7e6dd803539758a9870bce042f46cb2eba5d"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "flate2",
+]
 
 [[package]]
 name = "ident_case"
@@ -1338,10 +1370,13 @@ name = "music-player"
 version = "0.1.0"
 dependencies = [
  "eframe",
+ "id3",
+ "itertools",
  "rfd",
  "rodio",
  "tracing",
  "tracing-subscriber",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,10 @@ edition = "2021"
 
 [dependencies]
 eframe = "0.15.0"
+id3 = "0.6"
+itertools = "0.10"
 rfd = "0.6"
 rodio = "0.14.0"
 tracing = "0.1.29"
 tracing-subscriber = "0.3.3"
+walkdir = "2"

--- a/README.md
+++ b/README.md
@@ -39,8 +39,13 @@ It is not meant to be used as a serious audio player.
 - [ ] Set currently playing track as app Title
 - [ ] Stop with all the cloning... seriously. Everything is cloned.
 - [ ] Handle files which can't be decoded correctly into audio. 
-- [ ] Implement library and text search.
+- [x] Implement library
+- [ ] Implement library search.
 - [ ] Playlist plays to end after track is selected.
 - [x] Un-named playlists get `(idx)` appended 
 - [x] Playlist tab section stacks playlist tabs when they don't fit.
 - [ ] Differentiate between a selected track and the currently playing one.
+- [ ] Refactor so the items parsed in the library are the primary data type passed around instead of separate library items and tracks.
+- [ ] Library display options [ album, artist, year, genre, folder structure, etc...]
+- [ ] Improve library build performance
+- [ ] Library Item hashable?

--- a/src/stuff/library.rs
+++ b/src/stuff/library.rs
@@ -1,0 +1,129 @@
+use id3::Tag;
+use std::path::PathBuf;
+use walkdir::WalkDir;
+
+#[derive(Debug, Clone)]
+pub struct Library {
+    root_path: PathBuf,
+    items: Option<Vec<LibraryItem>>,
+}
+
+impl Library {
+    pub fn new(root_path: PathBuf) -> Self {
+        Self {
+            root_path,
+            items: None,
+        }
+    }
+
+    pub fn build(&mut self) {
+        let mut items = vec![];
+
+        let files = WalkDir::new(&self.root_path)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .skip(1)
+            .filter(|entry| entry.file_type().is_file());
+
+        for entry in files {
+            let tag = Tag::read_from_path(&entry.path());
+
+            let library_item = match tag {
+                Ok(tag) => LibraryItem::new(entry.path().to_path_buf())
+                    .set_title(tag.title().unwrap_or("?").to_string())
+                    .set_artist(tag.artist().unwrap_or("?").to_string())
+                    .set_album(tag.album().unwrap_or("?").to_string())
+                    .set_year(tag.year().unwrap_or(0))
+                    .set_genre(tag.genre().unwrap_or("?").to_string()),
+                Err(_err) => {
+                    tracing::warn!("Couldn't parse to id3: {:?}", &entry.path());
+                    LibraryItem::new(entry.path().to_path_buf())
+                }
+            };
+
+            items.push(library_item.clone());
+        }
+
+        self.items = Some(items);
+    }
+
+    pub fn root_path(&self) -> PathBuf {
+        self.root_path.clone()
+    }
+
+    pub fn items(&self) -> Option<Vec<LibraryItem>> {
+        self.items.clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LibraryItem {
+    path: PathBuf,
+    title: Option<String>,
+    artist: Option<String>,
+    album: Option<String>,
+    year: Option<i32>,
+    genre: Option<String>,
+}
+
+impl LibraryItem {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            title: None,
+            artist: None,
+            album: None,
+            year: None,
+            genre: None,
+        }
+    }
+
+    pub fn path(&self) -> PathBuf {
+        self.path.clone()
+    }
+
+    pub fn set_title(&mut self, title: String) -> Self {
+        self.title = Some(title);
+        self.to_owned()
+    }
+
+    pub fn title(&self) -> Option<String> {
+        self.title.clone()
+    }
+
+    pub fn set_artist(&mut self, artist: String) -> Self {
+        self.artist = Some(artist);
+        self.to_owned()
+    }
+
+    pub fn artist(&self) -> Option<String> {
+        self.artist.clone()
+    }
+
+    pub fn set_album(&mut self, album: String) -> Self {
+        self.album = Some(album);
+        self.to_owned()
+    }
+
+    pub fn album(&self) -> Option<String> {
+        self.album.clone()
+    }
+
+    pub fn set_year(&mut self, year: i32) -> Self {
+        self.year = Some(year);
+        self.to_owned()
+    }
+
+    pub fn year(&self) -> Option<i32> {
+        self.year.clone()
+    }
+
+    pub fn set_genre(&mut self, genre: String) -> Self {
+        self.genre = Some(genre);
+        self.to_owned()
+    }
+
+    pub fn genre(&self) -> Option<String> {
+        self.genre.clone()
+    }
+}

--- a/src/stuff/mod.rs
+++ b/src/stuff/mod.rs
@@ -1,2 +1,3 @@
+pub mod library;
 pub mod player;
 pub mod playlist;

--- a/src/stuff/player.rs
+++ b/src/stuff/player.rs
@@ -54,7 +54,6 @@ impl Player {
                     self.track_state = TrackState::Playing;
                     self.sink.play();
                 }
-                _ => (),
             }
         }
     }
@@ -73,7 +72,7 @@ impl Player {
             _ => (),
         }
     }
-    
+
     pub fn previous(&mut self, playlist: &Playlist) {
         if let Some(selected_track) = &self.selected_track {
             if let Some(current_track_position) = playlist.get_pos(&selected_track) {
@@ -83,7 +82,6 @@ impl Player {
                     self.play();
                 }
             }
-
         }
     }
 


### PR DESCRIPTION
Add the most basic support for a music library.
- Can select a folder/directory
- Parses ID3 tags only
- Displays via album titles
- Double click to add to a playlist. This is awkward.  Figure out key events.
- Double click tracks in library to add to the playlist.
- Synchronous library building, which can block the UI thread :(