### PR TITLE
Playlist LibraryItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,28 @@ It is not meant to be used as a serious audio player.
 - [x] Reference playlists by index or actual reference (not a clone...), so info is not lost when changing playlist context
 - [x] Double clicking track automatically starts to play it.
 - [x] Remove playlists.
-- [ ] Remove tracks from playlist.
-- [ ] Reorder items in playlist.
-- [ ] Save playlists.
-- [ ] Selected track is highlighted.
+- [x] Un-named playlists get `(idx)` appended 
+- [x] Playlist tab section stacks playlist tabs when they don't fit.
 - [x] Add Next and Previous controls
 - [x] Pause is a toggle
 - [x] Play restarts the track
-- [ ] Add player indicators next to the track
 - [x] Add volume control slider
-- [ ] Save app state on close.
-- [ ] Set currently playing track as app Title
-- [ ] Stop with all the cloning... seriously. Everything is cloned.
-- [ ] Handle files which can't be decoded correctly into audio. 
 - [x] Implement library
-- [ ] Implement library search.
+- [x] Refactor so the items parsed in the library are the primary data type passed around instead of separate library items and tracks.
+- [ ] Selected track is highlighted.
+- [ ] Set currently playing track as app Title
+- [ ] Display playlist as a table [Playing, Track #, Artist, Album Title, etc... ]
+- [ ] Add player indicators next to the track
 - [ ] Playlist plays to end after track is selected.
-- [x] Un-named playlists get `(idx)` appended 
-- [x] Playlist tab section stacks playlist tabs when they don't fit.
+- [ ] Remove tracks from playlist.
+- [ ] Reorder items in playlist.
+- [ ] Save playlists.
+- [ ] Save app state on close.
+- [ ] Handle files which can't be decoded correctly into audio. 
+- [ ] Implement library search.
 - [ ] Differentiate between a selected track and the currently playing one.
-- [ ] Refactor so the items parsed in the library are the primary data type passed around instead of separate library items and tracks.
 - [ ] Library display options [ album, artist, year, genre, folder structure, etc...]
-- [ ] Improve library build performance
+- [ ] Improve library build performance and probably offload to a non-ui thread.
 - [ ] Library Item hashable?
+- [ ] Refactor into more sensible responsibilities.
+- [ ] Stop with all the cloning... seriously. Everything is cloned.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 mod stuff;
 use crate::stuff::library::{Library, LibraryItem};
 use crate::stuff::player::Player;
-use crate::stuff::playlist::{Playlist, Track};
+use crate::stuff::playlist::Playlist;
 
 struct AppState {
     pub player: Player,
@@ -85,9 +85,10 @@ impl epi::App for AppState {
                                                         {
                                                             let current_playlist = &mut self
                                                                 .playlists[*current_playlist_idx];
-                                                            let track = Track {
-                                                                path: item.path().clone(),
-                                                            };
+                                                            let track = LibraryItem::new(
+                                                                item.path().clone(),
+                                                            );
+
                                                             current_playlist.add(track);
                                                         }
                                                     }
@@ -102,9 +103,8 @@ impl epi::App for AppState {
 
                                                 if library_group.header_response.double_clicked() {
                                                     for item in items {
-                                                        let track = Track {
-                                                            path: item.path().clone(),
-                                                        };
+                                                        let track =
+                                                            LibraryItem::new(item.path().clone());
                                                         current_playlist.add(track);
                                                     }
                                                 }
@@ -178,26 +178,24 @@ impl AppState {
                     if ui.button("Add file to playlist").clicked() {
                         if let Some(path) = rfd::FileDialog::new().pick_file() {
                             tracing::debug!("Adding file to playlist");
-                            self.playlists[*current_playlist_idx].add(Track { path });
+                            self.playlists[*current_playlist_idx].add(LibraryItem::new(path));
                         }
                     }
 
                     for track in self.playlists[*current_playlist_idx].tracks.iter() {
                         let track_item = ui.add(
                             egui::Label::new(egui::RichText::new(
-                                track.path.clone().into_os_string().into_string().unwrap(),
+                                track.path().clone().into_os_string().into_string().unwrap(),
                             ))
                             .sense(egui::Sense::click()),
                         );
 
                         if track_item.double_clicked() {
-                            tracing::debug!("Double clicked {:?}", &track.path);
                             self.player.selected_track = Some(track.clone());
                             self.player.play();
                         }
 
                         if track_item.clicked() {
-                            tracing::debug!("Clicked {:?}", &track.path);
                             self.player.selected_track = Some(track.clone());
                         }
                     }
@@ -247,7 +245,7 @@ impl AppState {
 
                 ui.label(egui::RichText::new(
                     &selected_track
-                        .path
+                        .path()
                         .clone()
                         .into_os_string()
                         .into_string()

--- a/src/stuff/library.rs
+++ b/src/stuff/library.rs
@@ -56,7 +56,7 @@ impl Library {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct LibraryItem {
     path: PathBuf,
     title: Option<String>,

--- a/src/stuff/player.rs
+++ b/src/stuff/player.rs
@@ -1,8 +1,9 @@
-use crate::stuff::playlist::{Playlist, Track};
+use crate::stuff::library::LibraryItem;
+use crate::stuff::playlist::Playlist;
 
 pub struct Player {
     pub track_state: TrackState,
-    pub selected_track: Option<Track>,
+    pub selected_track: Option<LibraryItem>,
     pub sink: rodio::Sink,
     pub stream_handle: rodio::OutputStreamHandle,
     pub volume: f32,
@@ -32,7 +33,7 @@ impl Player {
     pub fn play(&mut self) {
         if let Some(selected_track) = &self.selected_track {
             let file = std::io::BufReader::new(
-                std::fs::File::open(&selected_track.path).expect("Failed to open file"),
+                std::fs::File::open(&selected_track.path()).expect("Failed to open file"),
             );
             let source = rodio::Decoder::new(file).expect("Failed to decode audio file");
 

--- a/src/stuff/playlist.rs
+++ b/src/stuff/playlist.rs
@@ -1,14 +1,13 @@
+use crate::stuff::library::LibraryItem;
 use std::path::PathBuf;
 
-// TODO - Stop all the clonin'!
 #[derive(Debug, Clone)]
 pub struct Playlist {
     name: Option<String>,
-    pub tracks: Vec<Track>,
-    pub selected: Option<Track>,
+    pub tracks: Vec<LibraryItem>,
+    pub selected: Option<LibraryItem>,
 }
 
-// TODO impl a builder pattern?
 impl Playlist {
     pub fn new() -> Self {
         Self {
@@ -26,7 +25,7 @@ impl Playlist {
         self.name.clone()
     }
 
-    pub fn add(&mut self, track: Track) {
+    pub fn add(&mut self, track: LibraryItem) {
         self.tracks.push(track);
     }
 
@@ -46,15 +45,9 @@ impl Playlist {
         self.selected = Some(self.tracks[idx].clone());
     }
 
-    pub fn get_pos(&self, track: &Track) -> Option<usize> {
+    pub fn get_pos(&self, track: &LibraryItem) -> Option<usize> {
         self.tracks.iter().position(|t| t == track)
     }
-}
-
-// TODO - Probably shouldn't hold the actual bytes, but borrowed tag information after the file is opened.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Track {
-    pub path: PathBuf,
 }
 
 #[cfg(test)]
@@ -82,9 +75,7 @@ mod tests {
 
     #[test]
     fn add_track_to_playlist() {
-        let track = Track {
-            path: PathBuf::from(r"C:\music\song.mp3"),
-        };
+        let track = LibraryItem::new(PathBuf::from(r"C:\music\song.mp3"));
 
         let mut playlist = Playlist::new();
         playlist.add(track);
@@ -101,15 +92,9 @@ mod tests {
         let mut playlist = Playlist {
             name: Some("test".to_string()),
             tracks: vec![
-                Track {
-                    path: path1.clone(),
-                },
-                Track {
-                    path: path2.clone(),
-                },
-                Track {
-                    path: path3.clone(),
-                },
+                LibraryItem::new(path1.clone()),
+                LibraryItem::new(path2.clone()),
+                LibraryItem::new(path3.clone()),
             ],
             selected: None,
         };
@@ -119,8 +104,8 @@ mod tests {
         playlist.remove(1);
 
         assert_eq!(playlist.tracks.len(), 2);
-        assert_eq!(playlist.tracks.first().unwrap().path, path1);
-        assert_eq!(playlist.tracks.last().unwrap().path, path3);
+        assert_eq!(playlist.tracks.first().unwrap().path(), path1);
+        assert_eq!(playlist.tracks.last().unwrap().path(), path3);
     }
 
     #[test]
@@ -132,15 +117,9 @@ mod tests {
         let mut playlist = Playlist {
             name: Some("test".to_string()),
             tracks: vec![
-                Track {
-                    path: path1.clone(),
-                },
-                Track {
-                    path: path2.clone(),
-                },
-                Track {
-                    path: path3.clone(),
-                },
+                LibraryItem::new(path1.clone()),
+                LibraryItem::new(path2.clone()),
+                LibraryItem::new(path3.clone()),
             ],
             selected: None,
         };
@@ -150,22 +129,16 @@ mod tests {
         playlist.reorder(0, 2);
 
         assert_eq!(playlist.tracks.len(), 3);
-        assert_eq!(playlist.tracks[0].path, path2);
-        assert_eq!(playlist.tracks[1].path, path3);
-        assert_eq!(playlist.tracks[2].path, path1);
+        assert_eq!(playlist.tracks[0].path(), path2);
+        assert_eq!(playlist.tracks[1].path(), path3);
+        assert_eq!(playlist.tracks[2].path(), path1);
     }
 
     #[test]
     fn select_track() {
-        let track1 = Track {
-            path: PathBuf::from(r"C:\music\song1.mp3"),
-        };
-        let track2 = Track {
-            path: PathBuf::from(r"C:\music\song2.mp3"),
-        };
-        let track3 = Track {
-            path: PathBuf::from(r"C:\music\song3.mp3"),
-        };
+        let track1 = LibraryItem::new(PathBuf::from(r"C:\music\song1.mp3"));
+        let track2 = LibraryItem::new(PathBuf::from(r"C:\music\song2.mp3"));
+        let track3 = LibraryItem::new(PathBuf::from(r"C:\music\song3.mp3"));
 
         let mut playlist = Playlist {
             name: Some("test".to_string()),


### PR DESCRIPTION
Instead of keeping two separate structs, use the `LibraryItem`. It not only holds the path, but it also holds the id3 tag data, which can be used by several views.