### PR TITLE
Set currently playing track as the app title

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ It is not meant to be used as a serious audio player.
 - [x] Add volume control slider
 - [x] Implement library
 - [x] Refactor so the items parsed in the library are the primary data type passed around instead of separate library items and tracks.
+- [x] Set currently playing track as app Title
 - [ ] Selected track is highlighted.
-- [ ] Set currently playing track as app Title
 - [ ] Display playlist as a table [Playing, Track #, Artist, Album Title, etc... ]
 - [ ] Add player indicators next to the track
+- [ ] Add toolbar with File, Properties, Help, etc...
 - [ ] Playlist plays to end after track is selected.
 - [ ] Remove tracks from playlist.
 - [ ] Reorder items in playlist.

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,17 @@ struct AppState {
 }
 
 impl epi::App for AppState {
-    fn update(&mut self, ctx: &egui::CtxRef, _frame: &epi::Frame) {
+    fn update(&mut self, ctx: &egui::CtxRef, frame: &epi::Frame) {
+        if let Some(selected_track) = &self.player.selected_track {
+            let display = format!(
+                "{} - {} [ Music Player ]",
+                &selected_track.artist().unwrap_or("?".to_string()),
+                &selected_track.title().unwrap_or("?".to_string())
+            );
+
+            frame.set_window_title(&display);
+        }
+
         egui::TopBottomPanel::top("MusicPlayer").show(ctx, |ui| {
             ui.label("Welcome to MusicPlayer!");
         });
@@ -85,11 +95,8 @@ impl epi::App for AppState {
                                                         {
                                                             let current_playlist = &mut self
                                                                 .playlists[*current_playlist_idx];
-                                                            let track = LibraryItem::new(
-                                                                item.path().clone(),
-                                                            );
 
-                                                            current_playlist.add(track);
+                                                            current_playlist.add(item.clone());
                                                         }
                                                     }
                                                 }
@@ -103,9 +110,7 @@ impl epi::App for AppState {
 
                                                 if library_group.header_response.double_clicked() {
                                                     for item in items {
-                                                        let track =
-                                                            LibraryItem::new(item.path().clone());
-                                                        current_playlist.add(track);
+                                                        current_playlist.add(item.clone());
                                                     }
                                                 }
                                             }
@@ -137,16 +142,12 @@ impl AppState {
                         );
 
                         if playlist_tab.clicked() {
-                            tracing::info!("playlist tab was clicked");
                             self.current_playlist_idx = Some(idx);
                         }
 
+                        // TODO - make this bring up a context menu, however just delete for
+                        // now.
                         if playlist_tab.clicked_by(egui::PointerButton::Secondary) {
-                            tracing::info!("Right clicked the playlist tab idx {}", idx);
-
-                            // TODO - make this bring up a context menu, however just delete for
-                            // now.
-
                             self.playlist_idx_to_remove = Some(idx);
                         }
                     }
@@ -177,7 +178,6 @@ impl AppState {
                 if let Some(current_playlist_idx) = &mut self.current_playlist_idx {
                     if ui.button("Add file to playlist").clicked() {
                         if let Some(path) = rfd::FileDialog::new().pick_file() {
-                            tracing::debug!("Adding file to playlist");
                             self.playlists[*current_playlist_idx].add(LibraryItem::new(path));
                         }
                     }


### PR DESCRIPTION
The app should no longer be creating `LibraryItem`s after the library is loaded. This lead to a bug where items in the playlist were missing the data from the library. Additionally they are all cloned, which means they can have separate state. That is one aspect of a refactoring I would like to look into. 

The app now changes the window title when a track is selected to play.