### PR TITLE
Add track number and implement the player menu

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,11 +74,33 @@ impl epi::App for AppState {
                 });
 
                 ui.menu_button("Playback", |ui| {
-                    ui.button("Play");
-                    ui.button("Stop");
-                    ui.button("Pause");
-                    ui.button("Next");
-                    ui.button("Previous");
+                    let play_btn = ui.button("Play");
+                    let stop_btn = ui.button("Stop");
+                    let pause_btn = ui.button("Pause");
+                    let next_btn = ui.button("Next");
+                    let prev_btn = ui.button("Previous");
+
+                    if let Some(selected_track) = &self.player.selected_track {
+                        if play_btn.clicked() {
+                            self.player.play();
+                        }
+
+                        if stop_btn.clicked() {
+                            self.player.stop();
+                        }
+                        
+                        if pause_btn.clicked() {
+                            self.player.pause();
+                        }
+
+                        if next_btn.clicked() {
+                            self.player.next(&self.playlists[(self.current_playlist_idx).unwrap()])
+                        }
+
+                        if prev_btn.clicked() {
+                            self.player.previous(&self.playlists[(self.current_playlist_idx).unwrap()])
+                        }
+                    }
                 });
 
                 ui.menu_button("Library", |ui| {
@@ -106,8 +128,11 @@ impl epi::App for AppState {
                         ui.label(egui::RichText::new(
                             &selected_track
                                 .path()
+                                .as_path()
+                                .file_name()
+                                .unwrap()
                                 .clone()
-                                .into_os_string()
+                                .to_os_string()
                                 .into_string()
                                 .unwrap(),
                         ));
@@ -291,7 +316,11 @@ impl AppState {
                                 ui.label(" ".to_string());
                             }
 
-                            ui.label("0".to_string());
+                            if let Some(track_number) = &track.track_number() {
+                                ui.label(&track.track_number().unwrap().to_string());
+                            } else {
+                                ui.label("");
+                            }
 
                             let artist_label = ui.add(
                                 egui::Label::new(&track.artist().unwrap_or("?".to_string()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,17 +88,19 @@ impl epi::App for AppState {
                         if stop_btn.clicked() {
                             self.player.stop();
                         }
-                        
+
                         if pause_btn.clicked() {
                             self.player.pause();
                         }
 
                         if next_btn.clicked() {
-                            self.player.next(&self.playlists[(self.current_playlist_idx).unwrap()])
+                            self.player
+                                .next(&self.playlists[(self.current_playlist_idx).unwrap()])
                         }
 
                         if prev_btn.clicked() {
-                            self.player.previous(&self.playlists[(self.current_playlist_idx).unwrap()])
+                            self.player
+                                .previous(&self.playlists[(self.current_playlist_idx).unwrap()])
                         }
                     }
                 });

--- a/src/stuff/library.rs
+++ b/src/stuff/library.rs
@@ -34,7 +34,8 @@ impl Library {
                     .set_artist(tag.artist())
                     .set_album(tag.album())
                     .set_year(tag.year())
-                    .set_genre(tag.genre()),
+                    .set_genre(tag.genre())
+                    .set_track_number(tag.track()),
                 Err(_err) => {
                     tracing::warn!("Couldn't parse to id3: {:?}", &entry.path());
                     LibraryItem::new(entry.path().to_path_buf())
@@ -64,6 +65,7 @@ pub struct LibraryItem {
     album: Option<String>,
     year: Option<i32>,
     genre: Option<String>,
+    track_number: Option<u32>,
 }
 
 impl LibraryItem {
@@ -75,6 +77,7 @@ impl LibraryItem {
             album: None,
             year: None,
             genre: None,
+            track_number: None,
         }
     }
 
@@ -134,5 +137,15 @@ impl LibraryItem {
 
     pub fn genre(&self) -> Option<String> {
         self.genre.clone()
+    }
+
+
+    pub fn set_track_number(&mut self, track_number: Option<u32>) -> Self {
+        self.track_number = track_number;
+        self.to_owned()
+    }
+
+    pub fn track_number(&self) -> Option<u32> {
+        self.track_number.clone()
     }
 }

--- a/src/stuff/library.rs
+++ b/src/stuff/library.rs
@@ -139,7 +139,6 @@ impl LibraryItem {
         self.genre.clone()
     }
 
-
     pub fn set_track_number(&mut self, track_number: Option<u32>) -> Self {
         self.track_number = track_number;
         self.to_owned()


### PR DESCRIPTION
Add support for track number from the id3 tag. Implement the player functionality in the Player menu bar item. Change the track state footer to show only the filename that is currently playing instead of the full path.