### PR TITLE
Use confy with the Yaml feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "confy"
+version = "0.4.0"
+source = "git+https://github.com/rust-cli/confy#664992aecd97b4af0eda8d9d2825885662e1c6b4"
+dependencies = [
+ "directories-next",
+ "serde",
+ "serde_yaml",
+]
+
+[[package]]
 name = "copypasta"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +605,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -953,6 +984,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1029,16 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
 
 [[package]]
 name = "instant"
@@ -1108,6 +1155,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "winapi",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
@@ -1231,6 +1284,7 @@ dependencies = [
 name = "music-player"
 version = "0.1.0"
 dependencies = [
+ "confy",
  "eframe",
  "id3",
  "itertools",
@@ -1714,6 +1768,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,6 +1896,18 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -2471,3 +2547,12 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,11 @@ serde_json = "1"
 tracing = "0.1.29"
 tracing-subscriber = "0.3.3"
 walkdir = "2"
+
+[dependencies.confy]
+version = "0.4.0"
+features = ["yaml_conf"]
+default-features = false
+
+[patch.crates-io]
+confy = { git = 'https://github.com/rust-cli/confy' }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It is not meant to be used as a serious audio player.
 - [x] Improve library build performance and probably offload to a non-ui thread.
 - [x] Add toolbar with File, Properties, Help, etc...
 - [x] Save app state on close (just get it working bare min with a random file).
-- [ ] Use Confy for app state load/save
+- [x] Use Confy for app state load/save
 - [ ] Figure out error handling (anyhow, eyre, thiserror, etc...)
 - [ ] Refactor into more sensible responsibilities (think components / widgets / features).
 - [ ] Remove tracks from playlist.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
+use eframe::epi;
 use library::{Library, LibraryItem};
 use player::Player;
 use playlist::Playlist;
@@ -61,20 +62,15 @@ impl std::fmt::Display for TempError {
 
 impl App {
     pub fn load() -> Result<Self, TempError> {
-        let mut saved_state = String::new();
-        let mut file =
-            File::open("./music_player_app.json").map_err(|_| TempError::MissingAppState)?;
-        file.read_to_string(&mut saved_state)
-            .map_err(|_| TempError::MissingAppState)?;
-        serde_json::from_str(&saved_state).map_err(|_| TempError::MissingAppState)
+        confy::load("music_player", None).map_err(|_| TempError::MissingAppState)
     }
 
     pub fn save_state(&self) {
-        let config = serde_json::to_string(&self).unwrap();
-        let location = "./music_player_app.json";
-
-        let mut file = File::create(location).unwrap();
-        file.write_all(config.as_bytes()).unwrap();
+        let store_result = confy::store("music_player", None, &self);
+        match store_result {
+            Ok(_) => tracing::info!("Store was successfull"),
+            Err(err) => tracing::error!("Failed to store the app state: {}", err),
+        }
     }
 
     fn main_window(&mut self, ctx: &egui::CtxRef) {


### PR DESCRIPTION
Use Confy so reasonable paths are used. The toml feature didn't work, so I'm using the Yaml feature. Confy looks like it isn't being actively developed, so this may be worth refactoring into a sub-crate.