### PR TITLE
Audio load performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,7 @@ dependencies = [
  "rand",
  "rayon",
  "rfd",
+ "ringbuf",
  "rubato",
  "serde",
  "serde_json",
@@ -2382,6 +2383,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows 0.28.0",
+]
+
+[[package]]
+name = "ringbuf"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ca10b9c9e53ac855a2d6953bce34cef6edbac32c4b13047a4d59d67299420a"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,6 +1651,7 @@ dependencies = [
  "id3",
  "itertools",
  "minimp3",
+ "rand",
  "rayon",
  "rfd",
  "rubato",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tracing-subscriber = "0.3.3"
 walkdir = "2"
 rubato = "0.12.0"
 rand = "0.8.5"
+ringbuf = "0.3.2"
 
 [dependencies.confy]
 version = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tracing = "0.1.29"
 tracing-subscriber = "0.3.3"
 walkdir = "2"
 rubato = "0.12.0"
+rand = "0.8.5"
 
 [dependencies.confy]
 version = "0.4.0"

--- a/src/app/components/library_component.rs
+++ b/src/app/components/library_component.rs
@@ -12,6 +12,8 @@ impl AppComponent for LibraryComponent {
     type Context = App;
 
     fn add(ctx: &mut Self::Context, ui: &mut eframe::egui::Ui) {
+        let audio_cmd_tx = &ctx.player.as_ref().unwrap().audio_tx;
+
         eframe::egui::ScrollArea::both().show(ui, |ui| {
             // TODO - Store library paths and only import if the library path doesn't already exist
             if ui.button("Add Library path").clicked() {
@@ -129,7 +131,7 @@ impl AppComponent for LibraryComponent {
                                             let current_playlist =
                                                 &mut ctx.playlists[*current_playlist_idx];
 
-                                            current_playlist.add(item.clone());
+                                            current_playlist.add(item.clone(), &audio_cmd_tx);
                                         }
                                     }
                                 }
@@ -140,7 +142,7 @@ impl AppComponent for LibraryComponent {
 
                                 if library_group.header_response.double_clicked() {
                                     for item in items {
-                                        current_playlist.add(item.clone());
+                                        current_playlist.add(item.clone(), &audio_cmd_tx);
                                     }
                                 }
                             }

--- a/src/app/components/library_component.rs
+++ b/src/app/components/library_component.rs
@@ -12,8 +12,6 @@ impl AppComponent for LibraryComponent {
     type Context = App;
 
     fn add(ctx: &mut Self::Context, ui: &mut eframe::egui::Ui) {
-        let audio_cmd_tx = &ctx.player.as_ref().unwrap().audio_tx;
-
         eframe::egui::ScrollArea::both().show(ui, |ui| {
             // TODO - Store library paths and only import if the library path doesn't already exist
             if ui.button("Add Library path").clicked() {
@@ -131,7 +129,7 @@ impl AppComponent for LibraryComponent {
                                             let current_playlist =
                                                 &mut ctx.playlists[*current_playlist_idx];
 
-                                            current_playlist.add(item.clone(), &audio_cmd_tx);
+                                            current_playlist.add(item.clone());
                                         }
                                     }
                                 }
@@ -142,7 +140,7 @@ impl AppComponent for LibraryComponent {
 
                                 if library_group.header_response.double_clicked() {
                                     for item in items {
-                                        current_playlist.add(item.clone(), &audio_cmd_tx);
+                                        current_playlist.add(item.clone());
                                     }
                                 }
                             }

--- a/src/app/components/playlist_table.rs
+++ b/src/app/components/playlist_table.rs
@@ -52,7 +52,8 @@ impl AppComponent for PlaylistTable {
                         // Temporary hack because I don't yet know how to treat an entire Row
                         // as a response
                         if artist_label.double_clicked() {
-                            ctx.player.as_mut().unwrap().selected_track = Some(track.clone());
+                            //ctx.player.as_mut().unwrap().selected_track = Some(track.clone());
+                            ctx.player.as_mut().unwrap().select_track(Some(track.clone()));
                             ctx.player.as_mut().unwrap().play();
                         }
 

--- a/src/app/components/playlist_table.rs
+++ b/src/app/components/playlist_table.rs
@@ -53,7 +53,10 @@ impl AppComponent for PlaylistTable {
                         // as a response
                         if artist_label.double_clicked() {
                             //ctx.player.as_mut().unwrap().selected_track = Some(track.clone());
-                            ctx.player.as_mut().unwrap().select_track(Some(track.clone()));
+                            ctx.player
+                                .as_mut()
+                                .unwrap()
+                                .select_track(Some(track.clone()));
                             ctx.player.as_mut().unwrap().play();
                         }
 

--- a/src/app/library.rs
+++ b/src/app/library.rs
@@ -50,10 +50,12 @@ pub struct LibraryItem {
     year: Option<i32>,
     genre: Option<String>,
     track_number: Option<u32>,
+    key: usize,
 }
 
 impl LibraryItem {
     pub fn new(path: PathBuf) -> Self {
+        use rand::Rng;
         Self {
             path,
             title: None,
@@ -62,11 +64,16 @@ impl LibraryItem {
             year: None,
             genre: None,
             track_number: None,
+            key: rand::thread_rng().gen(),
         }
     }
 
     pub fn path(&self) -> PathBuf {
         self.path.clone()
+    }
+
+    pub fn key(&self) -> usize {
+        self.key
     }
 
     pub fn set_title(&mut self, title: Option<&str>) -> Self {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -15,7 +15,7 @@ pub enum AudioCommand {
     Play,
     Pause,
     Seek(u32), // Maybe this should represent a duration?
-    LoadFile(std::path::PathBuf, usize),
+    LoadFile(std::path::PathBuf),
     Select(usize),
     SetVolume(f32),
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -15,7 +15,8 @@ pub enum AudioCommand {
     Play,
     Pause,
     Seek(u32), // Maybe this should represent a duration?
-    LoadFile(std::path::PathBuf),
+    LoadFile(std::path::PathBuf, usize),
+    Select(usize),
     SetVolume(f32),
 }
 

--- a/src/app/player.rs
+++ b/src/app/player.rs
@@ -26,6 +26,16 @@ impl Player {
         }
     }
 
+    pub fn select_track(&mut self, track: Option<LibraryItem>) {
+        self.selected_track = track; 
+
+        if let Some(track) = &self.selected_track {
+            self.audio_tx
+                .send(AudioCommand::Select(track.key()))
+                .expect("Failed to send select to audio thread");
+        }
+    }
+
     pub fn is_stopped(&self) -> bool {
         match self.track_state {
             TrackState::Stopped => true,
@@ -48,7 +58,6 @@ impl Player {
                 self.audio_tx
                     .send(AudioCommand::Stop)
                     .expect("Failed to send stop to audio thread");
-                //self.sink.stop();
             }
             _ => (),
         }
@@ -56,14 +65,14 @@ impl Player {
 
     // TODO: Should return Result
     pub fn play(&mut self) {
-        if let Some(selected_track) = &self.selected_track {
+        if let Some(_selected_track) = &self.selected_track {
             match self.track_state {
                 TrackState::Unstarted | TrackState::Stopped | TrackState::Playing => {
                     self.track_state = TrackState::Playing;
-                    let track_path = selected_track.path();
+
                     self.audio_tx
-                        .send(AudioCommand::LoadFile(track_path))
-                        .expect("Failed to send to audio thread");
+                        .send(AudioCommand::Play)
+                        .expect("Failed to send play to audio thread");
                 }
                 TrackState::Paused => {
                     self.track_state = TrackState::Playing;

--- a/src/app/player.rs
+++ b/src/app/player.rs
@@ -27,7 +27,7 @@ impl Player {
     }
 
     pub fn select_track(&mut self, track: Option<LibraryItem>) {
-        self.selected_track = track; 
+        self.selected_track = track;
 
         if let Some(track) = &self.selected_track {
             self.audio_tx

--- a/src/app/player.rs
+++ b/src/app/player.rs
@@ -57,13 +57,6 @@ impl Player {
     // TODO: Should return Result
     pub fn play(&mut self) {
         if let Some(selected_track) = &self.selected_track {
-            /*
-            let file = std::io::BufReader::new(
-                std::fs::File::open(&selected_track.path()).expect("Failed to open file"),
-            );
-            */
-            //let source = rodio::Decoder::new(file).expect("Failed to decode audio file");
-
             match self.track_state {
                 TrackState::Unstarted | TrackState::Stopped | TrackState::Playing => {
                     self.track_state = TrackState::Playing;
@@ -71,25 +64,12 @@ impl Player {
                     self.audio_tx
                         .send(AudioCommand::LoadFile(track_path))
                         .expect("Failed to send to audio thread");
-
-                    /*
-                    let sink_try = rodio::Sink::try_new(&self.stream_handle);
-
-                    match sink_try {
-                        Ok(sink) => {
-                            self.sink = sink;
-                            self.sink.append(source);
-                        }
-                        Err(e) => tracing::error!("{:?}", e),
-                    }
-                    */
                 }
                 TrackState::Paused => {
                     self.track_state = TrackState::Playing;
                     self.audio_tx
                         .send(AudioCommand::Play)
                         .expect("Failed to send play to audio thread");
-                    //self.sink.play();
                 }
             }
         }
@@ -103,14 +83,12 @@ impl Player {
                 self.audio_tx
                     .send(AudioCommand::Pause)
                     .expect("Failed to send pause to audio thread");
-                //self.sink.pause();
             }
             TrackState::Paused => {
                 self.track_state = TrackState::Playing;
                 self.audio_tx
                     .send(AudioCommand::Play)
                     .expect("Failed to send play to audio thread");
-                //self.sink.play();
             }
             _ => (),
         }

--- a/src/app/player.rs
+++ b/src/app/player.rs
@@ -31,7 +31,7 @@ impl Player {
 
         if let Some(track) = &self.selected_track {
             self.audio_tx
-                .send(AudioCommand::Select(track.key()))
+                .send(AudioCommand::LoadFile(track.path()))
                 .expect("Failed to send select to audio thread");
         }
     }
@@ -108,7 +108,7 @@ impl Player {
             if let Some(current_track_position) = playlist.get_pos(&selected_track) {
                 if current_track_position > 0 {
                     let previous_track = &playlist.tracks[current_track_position - 1];
-                    self.selected_track = Some(previous_track.clone());
+                    self.select_track(Some((*previous_track).clone()));
                     self.play();
                 }
             }
@@ -120,7 +120,7 @@ impl Player {
             if let Some(current_track_position) = playlist.get_pos(&selected_track) {
                 if current_track_position < playlist.tracks.len() - 1 {
                     let next_track = &playlist.tracks[current_track_position + 1];
-                    self.selected_track = Some(next_track.clone());
+                    self.select_track(Some((*next_track).clone()));
                     self.play();
                 }
             }

--- a/src/app/playlist.rs
+++ b/src/app/playlist.rs
@@ -27,12 +27,7 @@ impl Playlist {
         self.name.clone()
     }
 
-    pub fn add(&mut self, track: LibraryItem, audio_cmd_tx: &Sender<AudioCommand>) {
-        let track_path = &track.path().clone();
-        audio_cmd_tx
-            .send(AudioCommand::LoadFile((*track_path.clone()).to_path_buf()))
-            .expect("Failed to send to audio thread");
-
+    pub fn add(&mut self, track: LibraryItem) {
         self.tracks.push(track);
     }
 

--- a/src/app/playlist.rs
+++ b/src/app/playlist.rs
@@ -1,6 +1,6 @@
 use crate::app::LibraryItem;
-use serde::{Deserialize, Serialize};
 use crate::AudioCommand;
+use serde::{Deserialize, Serialize};
 use std::sync::mpsc::Sender;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/app/playlist.rs
+++ b/src/app/playlist.rs
@@ -29,9 +29,8 @@ impl Playlist {
 
     pub fn add(&mut self, track: LibraryItem, audio_cmd_tx: &Sender<AudioCommand>) {
         let track_path = &track.path().clone();
-        let key = &track.key();
         audio_cmd_tx
-            .send(AudioCommand::LoadFile((*track_path.clone()).to_path_buf(), *key))
+            .send(AudioCommand::LoadFile((*track_path.clone()).to_path_buf()))
             .expect("Failed to send to audio thread");
 
         self.tracks.push(track);
@@ -52,9 +51,9 @@ impl Playlist {
     pub fn select(&mut self, idx: usize, audio_cmd_tx: &Sender<AudioCommand>) {
         tracing::info!("SELECTED");
         let track = self.tracks[idx].clone();
-        let key = &track.key();
+        let path = &track.path();
         audio_cmd_tx
-            .send(AudioCommand::Select(*key))
+            .send(AudioCommand::LoadFile((*path).clone()))
             .expect("Failed to send to audio thread");
 
         self.selected = Some(track);

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,10 @@ use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::SampleFormat;
 use eframe::egui;
 use minimp3::{Decoder, Frame};
-use rubato::{InterpolationParameters, InterpolationType, Resampler, SincFixedIn, WindowFunction};
+use rubato::Resampler;
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{Read, Seek};
+use std::io::{Read, Seek, Write};
 use std::sync::atomic::{AtomicU32, Ordering::*};
 use std::sync::mpsc::channel;
 use std::sync::Arc;
@@ -18,7 +18,6 @@ use std::thread;
 
 mod app;
 
-// This holds several buffers
 pub struct AudioBank {
     pub buffers: HashMap<usize, AudioBuffer>,
     pub count: usize, // This can be replaced if we randomize the key for the map
@@ -152,6 +151,36 @@ where
         let frame_value = self.current_frame.data[self.current_frame_offset];
         self.current_frame_offset += 1;
         Some(frame_value)
+    }
+}
+
+
+fn read_frames<R: Read + Seek>(input_buffer: &mut R, nbr: usize, channels: usize) -> Vec<Vec<f32>> {
+    let mut buffer = vec![0u8; 4];
+    let mut wfs = Vec::with_capacity(channels);
+    for _chan in 0..channels {
+       wfs.push(Vec::with_capacity(nbr)); 
+    }
+    let mut value: f32;
+    for _frame in 0..nbr {
+        for wf in wfs.iter_mut().take(channels) {
+            input_buffer.read(&mut buffer).unwrap();
+            value = f32::from_le_bytes(buffer.as_slice().try_into().unwrap()) as f32;
+            wf.push(value);
+        }
+    }
+
+    wfs
+}
+
+fn write_frames<W: Write + Seek>(waves: Vec<Vec<f32>>, output_buffer: &mut W, channels: usize) {
+    let nbr = waves[0].len();
+    for frame in 0..nbr {
+        for chan in 0..channels {
+            let value = waves[chan][frame];
+            let bytes = value.to_le_bytes();
+            output_buffer.write(&bytes).unwrap();
+        }
     }
 }
 
@@ -324,68 +353,47 @@ fn main() {
                                     *guard = sample_rate; 
                                 }
 
-                                let mut the_samples = mp3_decoder.collect::<Vec<i16>>();
+                                let start = std::time::Instant::now();
+                                let raw_samples = mp3_decoder
+                                    .flat_map(|sample| (sample as f32).to_le_bytes())
+                                    .collect::<Vec<u8>>();
 
-                                if sample_rate != device_sample_rate {
-                                    tracing::info!("Resampling from {sample_rate} to {device_sample_rate}");
-                                    let mut left = vec![];
-                                    let mut right = vec![];
-                                    for (idx, sample) in the_samples.iter().enumerate() {
-                                        if idx % 2 == 0 {
-                                            left.push(*sample as f32);
-                                        } else {
-                                            right.push(*sample as f32);
-                                        }
+                                let mut input_cursor = std::io::Cursor::new(&raw_samples);
+                                let capacity = (*(&raw_samples.len()) as f32 * (device_sample_rate as f32 / sample_rate as f32)) as usize;
+                                let mut output_buffer = Vec::with_capacity(capacity);
+                                let mut output_cursor = std::io::Cursor::new(&mut output_buffer);
+                                let channels = 2;
+                                let chunk_size = 1024;
+                                let sub_chunks = 2;
+
+                                let mut fft_resampler = rubato::FftFixedIn::<f32>::new(
+                                    44100 as usize,
+                                    48000 as usize,
+                                    chunk_size,
+                                    sub_chunks,
+                                    channels
+                                ).unwrap();
+
+                                let num_frames_per_channel = fft_resampler.input_frames_next();
+                                let sample_byte_size = 8;
+                                let num_chunks = &raw_samples.len() / (sample_byte_size * channels * num_frames_per_channel);
+
+                                for _chunk in 0..num_chunks {
+                                    let frame_data = read_frames(&mut input_cursor, num_frames_per_channel, channels);
+                                    let output = fft_resampler.process(&frame_data, None).unwrap();
+                                    write_frames(output, &mut output_cursor, channels);
+                                }
+
+                                let end = start.elapsed();
+                                tracing::info!("Done resampling file: {:?}ms", end);
+
+
+                                for bytes in output_buffer.iter().as_slice().chunks(4) {
+                                    let sample = (f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])) as i16;
+                                    {
+                                        let mut guard = ab.lock().unwrap();
+                                        guard.append_sample(key, sample);
                                     }
-
-                                    assert!(left.len() == right.len());
-
-                                    let params = InterpolationParameters {
-                                        sinc_len: 256,
-                                        f_cutoff: 0.95,
-                                        interpolation: InterpolationType::Linear,
-                                        oversampling_factor: 256,
-                                        window: WindowFunction::BlackmanHarris2,
-                                    };
-
-                                    let mut resampler = SincFixedIn::<f32>::new(
-                                        48_000 as f64 / 44_100 as f64, // should be using config_sample_rate / the mp3's sample_rate
-                                        2.0,
-                                        params,
-                                        left.len(),
-                                        2,
-                                    )
-                                    .unwrap();
-
-                                    let channels = vec![left, right];
-
-                                    let resampled_audio = resampler
-                                        .process(&channels, None)
-                                        .expect("failed to resample audio");
-
-                                    let zip_audio = resampled_audio[0]
-                                        .iter()
-                                        .zip(&resampled_audio[1])
-                                        .collect::<Vec<(&f32, &f32)>>();
-                                        //.flat_map(|z| vec![*z.0 as i16, *z.1 as i16])
-                                        //.collect::<Vec<i16>>();
-
-                                    let mut vec_channels = vec![];
-                                    for z in zip_audio {
-                                        vec_channels.push(vec![*z.0, *z.1]);
-                                    }
-
-                                    the_samples = vec_channels
-                                        .iter()
-                                        .flatten()
-                                        .map(|s| *s as i16)
-                                        .collect::<Vec<i16>>();
-                                } else { tracing::info!("no resampling needed"); }
-
-                                // append resampled data to audio bank buffer
-                                {
-                                    let mut guard = ab.lock().unwrap();
-                                    guard.append_samples(key, the_samples);
                                 }
 
                                 tracing::info!("Done loading file");


### PR DESCRIPTION
- Use FFT synchronous resampling. This seems to be the fastest way to sample the entire file.
- Use a ring buffer to drive the cpal audio sample callback.
- Extract some logic into new methods.
- This is okay, but not great. I've lost the ability to seek because I'm not using a cursor into a Vec anymore.