### PR TITLE
Scope improvements

### DIFF
--- a/src/app/components/scope_component.rs
+++ b/src/app/components/scope_component.rs
@@ -14,7 +14,7 @@ impl AppComponent for ScopeComponent {
             let _time = ui.input(|i| i.time);
             let color = Color32::from_additive_luminance(196);
 
-            let desired_size = ui.available_width() * vec2(1.0, 0.35);
+            let desired_size = ui.available_width() * vec2(1.0, 0.25);
             let (_id, rect) = ui.allocate_space(desired_size);
 
             let to_screen =
@@ -22,62 +22,35 @@ impl AppComponent for ScopeComponent {
             let mut shapes = vec![];
 
             // TODO - Need to figure out how to handle moving the data out of the scope buffer option... This creates redundant code.
-            if let Some(ref mut data) = &mut ctx.scope_buffer {
+            if let Some(ref mut scope) = &mut ctx.scope {
                 if let Some(audio_buf) = &ctx.played_audio_buffer {
-                    // let _num_bytes_read = audio_buf.read(&mut data).unwrap_or(0);
-                    let _num_bytes_read = audio_buf.read(data).unwrap_or(0);
+                    let mut local_buf = vec![0.0f32; 4096];
+                    let num_bytes_read = audio_buf.read(&mut local_buf).unwrap_or(0);
+
+                    for sample in (&local_buf[0..num_bytes_read]).iter().step_by(2) {
+                        scope.write_sample(*sample);
+                    }
                 }
 
-                let points: Vec<Pos2> = data
+                let points: Vec<Pos2> = scope
+                    .buffer
                     .iter()
-                    .step_by(2)
                     .enumerate()
-                    .map(|(i, sample)| to_screen * pos2(i as f32, *sample))
+                    .map(|(i, sample)| to_screen * pos2(i as f32 / (48000.0 * 3.0), *sample))
                     .collect();
+
+                // let points: Vec<Pos2> = scope
+                //     .into_iter()
+                //     .enumerate()
+                //     .map(|(i, sample)| to_screen * pos2(i as f32 / (48000.0 * 3.0), sample))
+                //     .collect();
+
 
                 shapes.push(crate::egui::epaint::Shape::line(
                     points,
-                    crate::egui::epaint::Stroke::new(2.0, color),
+                    crate::egui::epaint::Stroke::new(1.0, color),
                 ));
-            } else {
-                let mut data = vec![0.0f32; 4096];
-
-                if let Some(audio_buf) = &ctx.played_audio_buffer {
-                    // let _num_bytes_read = audio_buf.read(&mut data).unwrap_or(0);
-                    let _num_bytes_read = audio_buf.read(&mut data).unwrap_or(0);
-                }
-
-                let points: Vec<Pos2> = data
-                    .iter()
-                    .step_by(2)
-                    .enumerate()
-                    .map(|(i, sample)| to_screen * pos2(i as f32, *sample))
-                    .collect();
-
-                shapes.push(crate::egui::epaint::Shape::line(
-                    points,
-                    crate::egui::epaint::Stroke::new(2.0, color),
-                ));
-            }
-
-            // EGUI Dancing Strings Example
-            // for &mode in &[2,3,5] {
-            //     let mode = mode as f64;
-            //     let n = 120;
-            //     let speed = 1.5;
-
-            //     let points: Vec<Pos2> = (0..=n)
-            //         .map(|i| {
-            //             let t = i as f64 / (n as f64);
-            //             let amp = (time * speed * mode).sin() / mode;
-            //             let y = amp * (t * std::f64::consts::TAU / 2.0 * mode).sin();
-            //             to_screen * pos2(t as f32, y as f32)
-            //         })
-            //         .collect();
-
-            //     let thickness = 10.0 / mode as f32;
-            //     shapes.push(crate::egui::epaint::Shape::line(points, crate::egui::epaint::Stroke::new(thickness, color)));
-            // }
+            } 
 
             ui.painter().extend(shapes);
         });

--- a/src/app/components/scope_component.rs
+++ b/src/app/components/scope_component.rs
@@ -21,32 +21,18 @@ impl AppComponent for ScopeComponent {
                 emath::RectTransform::from_to(Rect::from_x_y_ranges(0.0..=1.0, -1.0..=1.0), rect);
             let mut shapes = vec![];
 
-            // TODO - Need to figure out how to handle moving the data out of the scope buffer option... This creates redundant code.
             if let Some(ref mut scope) = &mut ctx.scope {
                 if let Some(audio_buf) = &ctx.played_audio_buffer {
                     if let Some(local_buf) = &mut ctx.temp_buf {
                         let num_bytes_read = audio_buf.read(&mut local_buf[..]).unwrap_or(0);
 
                         if num_bytes_read > 0 {
-                            /*
-                            scope.write_samples(&local_buf[0..num_bytes_read]);
-                            */
-
                             for sample in (local_buf[0..num_bytes_read]).iter().step_by(2) {
                                 scope.write_sample(*sample);
                             }
                         }
                     }
                 }
-
-                /*
-                let points: Vec<Pos2> = scope
-                    .buffer
-                    .iter()
-                    .enumerate()
-                    .map(|(i, sample)| to_screen * pos2(i as f32 / (48000.0 * 3.0), *sample))
-                    .collect();
-                */
 
                 let points: Vec<Pos2> = scope
                     .into_iter()

--- a/src/app/components/scope_component.rs
+++ b/src/app/components/scope_component.rs
@@ -24,11 +24,18 @@ impl AppComponent for ScopeComponent {
             // TODO - Need to figure out how to handle moving the data out of the scope buffer option... This creates redundant code.
             if let Some(ref mut scope) = &mut ctx.scope {
                 if let Some(audio_buf) = &ctx.played_audio_buffer {
-                    let mut local_buf = vec![0.0f32; 4096];
-                    let num_bytes_read = audio_buf.read(&mut local_buf).unwrap_or(0);
+                    if let Some(local_buf) = &mut ctx.temp_buf {
+                        let num_bytes_read = audio_buf.read(&mut local_buf[..]).unwrap_or(0);
 
-                    for sample in (&local_buf[0..num_bytes_read]).iter().step_by(2) {
-                        scope.write_sample(*sample);
+                        if num_bytes_read > 0 {
+                            /*
+                            scope.write_samples(&local_buf[0..num_bytes_read]);
+                            */
+
+                            for sample in (local_buf[0..num_bytes_read]).iter().step_by(2) {
+                                scope.write_sample(*sample);
+                            }
+                        }
                     }
                 }
 
@@ -46,7 +53,6 @@ impl AppComponent for ScopeComponent {
                     .enumerate()
                     .map(|(i, sample)| to_screen * pos2(i as f32 / (48000.0 * 3.0), sample))
                     .collect();
-
 
                 shapes.push(crate::egui::epaint::Shape::line(
                     points,

--- a/src/app/components/scope_component.rs
+++ b/src/app/components/scope_component.rs
@@ -32,18 +32,20 @@ impl AppComponent for ScopeComponent {
                     }
                 }
 
+                /*
                 let points: Vec<Pos2> = scope
                     .buffer
                     .iter()
                     .enumerate()
                     .map(|(i, sample)| to_screen * pos2(i as f32 / (48000.0 * 3.0), *sample))
                     .collect();
+                */
 
-                // let points: Vec<Pos2> = scope
-                //     .into_iter()
-                //     .enumerate()
-                //     .map(|(i, sample)| to_screen * pos2(i as f32 / (48000.0 * 3.0), sample))
-                //     .collect();
+                let points: Vec<Pos2> = scope
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, sample)| to_screen * pos2(i as f32 / (48000.0 * 3.0), sample))
+                    .collect();
 
 
                 shapes.push(crate::egui::epaint::Shape::line(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,7 +1,7 @@
 use library::{Library, LibraryItem, LibraryView};
 use player::Player;
 use playlist::Playlist;
-use rb::Consumer;
+use scope::Scope;
 use serde::{Deserialize, Serialize};
 use std::sync::mpsc::{Receiver, Sender};
 
@@ -10,6 +10,7 @@ mod components;
 mod library;
 pub mod player;
 mod playlist;
+pub mod scope;
 
 pub enum AudioCommand {
     Stop,
@@ -51,7 +52,7 @@ pub struct App {
     pub played_audio_buffer: Option<rb::Consumer<f32>>,
 
     #[serde(skip_serializing, skip_deserializing)]
-    pub scope_buffer: Option<Vec<f32>>,
+    pub scope: Option<Scope>,
 
     #[serde(skip_serializing, skip_deserializing)]
     pub quit: bool,
@@ -68,7 +69,7 @@ impl Default for App {
             library_sender: None,
             library_receiver: None,
             played_audio_buffer: None,
-            scope_buffer: None,
+            scope: Some(Scope::new()),
             quit: false,
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -53,6 +53,9 @@ pub struct App {
 
     #[serde(skip_serializing, skip_deserializing)]
     pub scope: Option<Scope>,
+    
+    #[serde(skip_serializing, skip_deserializing)]
+    pub temp_buf: Option<Vec<f32>>,
 
     #[serde(skip_serializing, skip_deserializing)]
     pub quit: bool,
@@ -70,6 +73,7 @@ impl Default for App {
             library_receiver: None,
             played_audio_buffer: None,
             scope: Some(Scope::new()),
+            temp_buf: Some(vec![0.0f32; 4096]),
             quit: false,
         }
     }

--- a/src/app/scope.rs
+++ b/src/app/scope.rs
@@ -1,0 +1,38 @@
+
+pub struct Scope {
+    pub sample_idx: usize,
+    pub display_idx: isize,
+    pub buffer: Vec<f32>,
+}
+
+impl Scope {
+    pub fn new() -> Self {
+        Self {
+            sample_idx: 0,
+            display_idx: 0,
+            buffer: vec![0.0f32; 48000 * 3],
+        }
+    }
+
+    pub fn write_sample(&mut self, sample: f32) {
+        if self.sample_idx >= self.buffer.len() {
+            self.sample_idx -= self.buffer.len();
+        }
+
+        self.buffer[self.sample_idx] = sample;
+        self.sample_idx += 1;
+    }
+}
+
+// impl Iterator for Scope {
+//     type Item = f32;
+    
+//     fn next(&mut self) -> Option<Self::Item> {
+//         if self.display_idx >= self.buffer.len() as isize {
+//             return None;
+//         }
+
+//         self.display_idx += 1;
+//         Some(self.buffer[(self.display_idx - 1) as usize])
+//     }    
+// }

--- a/src/app/scope.rs
+++ b/src/app/scope.rs
@@ -20,6 +20,24 @@ impl Scope {
         self.buffer[self.write_idx] = sample;
         self.write_idx += 1;
     }
+
+    pub fn write_samples(&mut self, samples: &[f32]) {
+        // if slice can fit from write pointer to end, then write all at once.
+        // Otherwise, write from write idx to end of buf.
+        // then update write idx to beginning and write the remaining of slice.
+        if samples.len() > 0 && samples.len() <= self.buffer.len() - self.write_idx {
+            self.buffer[self.write_idx..(samples.len() + self.write_idx)].copy_from_slice(&samples);
+            self.write_idx += samples.len();
+        } else {
+            let remaining = self.buffer.len() - self.write_idx;
+            //tracing::info!("remaining: {}, write_idx: {}", remaining, self.write_idx);
+            self.buffer[self.write_idx..].copy_from_slice(&samples[..remaining]);
+            //self.write_idx -= self.buffer.len();
+            self.write_idx= 0;
+            //tracing::info!("remaining: {}, write_idx: {}, sample_len: {}", remaining, self.write_idx, samples.len());
+            self.buffer[self.write_idx..(samples.len() - remaining)].copy_from_slice(&samples[remaining..]);
+        }
+    }
 }
 
 impl<'a> IntoIterator for &'a Scope {
@@ -62,3 +80,4 @@ impl<'a> Iterator for ScopeIterator<'a> {
         Some(buffer[self.index]) 
     }
 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
-pub use crate::app::player::Player;
-pub use crate::app::App;
 pub use crate::app::*;
+pub use crate::app::App;
+pub use crate::app::player::Player;
+pub use crate::app::scope::Scope;
 
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU32;
@@ -42,7 +43,7 @@ fn main() {
 
     // App setup
     let mut app = App::load().unwrap_or_default();
-    app.scope_buffer = Some(vec![0.0f32; 4096]);
+    app.scope = Some(Scope::new());
     app.player = Some(player);
     app.library_sender = Some(tx);
     app.library_receiver = Some(rx);

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ fn main() {
     // App setup
     let mut app = App::load().unwrap_or_default();
     app.scope = Some(Scope::new());
+    app.temp_buf = Some(vec![0.0f32; 4096]);
     app.player = Some(player);
     app.library_sender = Some(tx);
     app.library_receiver = Some(rx);

--- a/src/output.rs
+++ b/src/output.rs
@@ -374,7 +374,6 @@ mod cpal {
             } else {
                 // Resampling is not required. Interleave the sample for cpal using a sample buffer.
                 self.sample_buf.copy_interleaved_ref(decoded);
-
                 self.sample_buf.samples()
             };
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -379,7 +379,7 @@ mod cpal {
             };
 
             // Write all samples to the ring buffer.
-            let _written_count_to_scope = gui_ring_buf_producer.write_blocking(
+            let _written_count_to_scope = gui_ring_buf_producer.write(
                 &samples
                     .iter()
                     .map(|s| s.to_sample::<f32>())


### PR DESCRIPTION
Display three seconds of one channel of audio in the oscilloscope. I figured out the reason it was consuming a ton of memory was the iterator went into an infinite loop because the read pointer surpassed the write pointer.